### PR TITLE
Change color of sub-heading and sidebar description #3

### DIFF
--- a/public/css/master.css
+++ b/public/css/master.css
@@ -166,7 +166,7 @@ h1.branding span {
     font-style: normal;
     font-weight: bold;
     letter-spacing: 3px;
-    color: #E2590E;
+    color: #C51212;
 }
 
 /*article list styling*/
@@ -329,7 +329,7 @@ section.articles>header>h1 {
     font-size: 20px;
     line-height: 23px;
     letter-spacing: .03em;
-    color: #E2590E;
+    color: #C51212;
     padding-top: 15px;
 }
 


### PR DESCRIPTION
Closes issue #3
- Change color of sub-heading sidebar p.about to #C51212
- Change color of sidebar description h1.branding span to #C51212
